### PR TITLE
only include '/' in tailscale serve for https mode

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
@@ -26,7 +26,11 @@ tailscale up $FLAGS
 
 # configure serve
 if [ -v TAILSCALE_SERVE_PORT ] && [ -v TAILSCALE_SERVE_MODE ]; then
-    tailscale serve "${TAILSCALE_SERVE_MODE}":443 / http://localhost:"${TAILSCALE_SERVE_PORT}"
+    if [[ $TAILSCALE_SERVE_MODE == "https" ]]; then
+        tailscale serve "${TAILSCALE_SERVE_MODE}":443 / http://localhost:"${TAILSCALE_SERVE_PORT}"
+    else
+        tailscale serve "${TAILSCALE_SERVE_MODE}":443 http://localhost:"${TAILSCALE_SERVE_PORT}"
+    fi
 fi
 
 # configure funnel


### PR DESCRIPTION
when I set `TAILSCALE_SERVE_MODE=tls-terminated-tcp`, the following warning appears in the logs:

```
error: invalid TCP source "/": missing port in address
```
Along with the usage help for `tailscale serve`

This change makes it so the run command will only include the `/` if `TAILSCALE_SERVE_MODE=https`, as it's the only mode that needs it according to the [docs](https://tailscale.com/kb/1242/tailscale-serve/).