### PR TITLE
Add Custom control server & fix serve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use to configure it.
 | `TAILSCALE_SERVE_PORT` | The port number that you want to expose on your tailnet. This will be the port of your DokuWiki, Transmission, or other container.                                                                                                                                                                            | `80`                                     |
 | `TAILSCALE_SERVE_MODE` | The mode you want to run Tailscale serving in. This should be `https` in most cases, but there may be times when you need to enable `tls-terminated-tcp` to deal with some weird edge cases like HTTP long-poll connections. See [here](https://tailscale.com/kb/1242/tailscale-serve/) for more information. | `https`                                  |
 | `TAILSCALE_FUNNEL`     | Set this to `true`, `1`, or `t` to enable [funnel](https://tailscale.com/kb/1243/funnel/). For more information about the accepted syntax, please read the [strconv.ParseBool documentation](https://pkg.go.dev/strconv#ParseBool) in the Go standard library.                                                | `on`                                     |
-| `TAILSCALE_CUSTOM_SERVER` | Set this value if you are using a custom login/control server (Such as headscale) | `https://headscale.example.com`
+| `TAILSCALE_LOGIN_SERVER` | Set this value if you are using a custom login/control server (Such as headscale) | `https://headscale.example.com`
 
 Something important to keep in mind is that you really should set up a
 separate volume for Tailscale state. Here is how to do that with the

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ use to configure it.
 | `TAILSCALE_SERVE_PORT` | The port number that you want to expose on your tailnet. This will be the port of your DokuWiki, Transmission, or other container.                                                                                                                                                                            | `80`                                     |
 | `TAILSCALE_SERVE_MODE` | The mode you want to run Tailscale serving in. This should be `https` in most cases, but there may be times when you need to enable `tls-terminated-tcp` to deal with some weird edge cases like HTTP long-poll connections. See [here](https://tailscale.com/kb/1242/tailscale-serve/) for more information. | `https`                                  |
 | `TAILSCALE_FUNNEL`     | Set this to `true`, `1`, or `t` to enable [funnel](https://tailscale.com/kb/1243/funnel/). For more information about the accepted syntax, please read the [strconv.ParseBool documentation](https://pkg.go.dev/strconv#ParseBool) in the Go standard library.                                                | `on`                                     |
+| `TAILSCALE_CUSTOM_SERVER` | Set this value if you are using a custom login/control server (Such as headscale) | `https://headscale.example.com`
 
 Something important to keep in mind is that you really should set up a
 separate volume for Tailscale state. Here is how to do that with the

--- a/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
@@ -22,9 +22,9 @@ if [ -v TAILSCALE_BE_EXIT_NODE ]; then
     FLAGS="${FLAGS} --advertise-exit-node=${TS_BE_EXIT_NODE}"
 fi
 
-if [ -v TAILSCALE_CUSTOM_SERVER ]; then
+if [ -v TAILSCALE_LOGIN_SERVER ]; then
     echo '[!] Using a custom login server'
-    FLAGS="${FLAGS} --login-server=${TAILSCALE_CUSTOM_SERVER}"
+    FLAGS="${FLAGS} --login-server=${TAILSCALE_LOGIN_SERVER}"
 fi
 
 tailscale up $FLAGS

--- a/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
@@ -23,7 +23,7 @@ if [ -v TAILSCALE_BE_EXIT_NODE ]; then
 fi
 
 if [ -v TAILSCALE_CUSTOM_SERVER ]; then
-    echo '[!] Using a custom login server: ${TAILSCALE_CUSTOM_SERVER}'
+    echo '[!] Using a custom login server'
     FLAGS="${FLAGS} --login-server=${TAILSCALE_CUSTOM_SERVER}"
 fi
 

--- a/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
@@ -34,7 +34,7 @@ if [ -v TAILSCALE_SERVE_PORT ] && [ -v TAILSCALE_SERVE_MODE ]; then
     if [[ $TAILSCALE_SERVE_MODE == "https" ]]; then
         tailscale serve "${TAILSCALE_SERVE_MODE}":443 / http://localhost:"${TAILSCALE_SERVE_PORT}"
     else
-        tailscale serve "${TAILSCALE_SERVE_MODE}":443 http://localhost:"${TAILSCALE_SERVE_PORT}"
+        tailscale serve "${TAILSCALE_SERVE_MODE}":80 / http://localhost:"${TAILSCALE_SERVE_PORT}"
     fi
 fi
 

--- a/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-tailscale-up/run
@@ -22,6 +22,11 @@ if [ -v TAILSCALE_BE_EXIT_NODE ]; then
     FLAGS="${FLAGS} --advertise-exit-node=${TS_BE_EXIT_NODE}"
 fi
 
+if [ -v TAILSCALE_CUSTOM_SERVER ]; then
+    echo '[!] Using a custom login server: ${TAILSCALE_CUSTOM_SERVER}'
+    FLAGS="${FLAGS} --login-server=${TAILSCALE_CUSTOM_SERVER}"
+fi
+
 tailscale up $FLAGS
 
 # configure serve


### PR DESCRIPTION
This PR adds support for the environment variable `TAILSCALE_CUSTOM_SERVER` so custom control planes (Such as Headscale) can be used.

Also fixes the `tailscale serve` command always serving port 443, and not actually working if `http` is set as the TAILSCALE_SERVE_MODE` value